### PR TITLE
Add multi-artist search fallback

### DIFF
--- a/Sockseek.Core.Tests/SearcherTests.cs
+++ b/Sockseek.Core.Tests/SearcherTests.cs
@@ -107,6 +107,30 @@ namespace Tests.Unit
         }
 
         [TestMethod]
+        public async Task SearchSong_RetriesSingleArtistWithoutRequiredLengthTolerance()
+        {
+            var response = new SearchResponse("User", 1, true, 1000, 0,
+            [
+                TestHelpers.CreateSlFile(@"Music\Knock2\No Limit\No Limit.mp3", length: 200),
+            ]);
+            var client = CreateMockClient([response]);
+            var settings = TestHelpers.CreateDefaultSettings().Download;
+            var searcher = CreateSearcher(client, settings);
+            var song = new SongJob(new SongQuery
+            {
+                Artist = "Knock2",
+                Album = "No Limit",
+                Title = "No Limit",
+                Length = 240,
+            });
+
+            await searcher.SearchSong(song, settings.Search, new ResponseData(), CancellationToken.None);
+
+            Assert.AreEqual(2, client.SearchCallCount);
+            Assert.AreEqual(1, song.Candidates?.Count ?? 0);
+        }
+
+        [TestMethod]
         public async Task SearchSong_UpdatesActivityPhaseThroughSearchAndProjection()
         {
             var client = CreateMockClient(TestHelpers.CreateTestIndex());

--- a/Sockseek.Core.Tests/SearcherTests.cs
+++ b/Sockseek.Core.Tests/SearcherTests.cs
@@ -131,6 +131,30 @@ namespace Tests.Unit
         }
 
         [TestMethod]
+        public async Task SearchSong_RetriesWithoutFeaturedArtistInTitle()
+        {
+            var response = new SearchResponse("User", 1, true, 1000, 0,
+            [
+                TestHelpers.CreateSlFile(@"Music\Knock2\Shyne 4 Me\Shyne 4 Me.mp3", length: 200),
+            ]);
+            var client = CreateMockClient([response]);
+            var settings = TestHelpers.CreateDefaultSettings().Download;
+            var searcher = CreateSearcher(client, settings);
+            var song = new SongJob(new SongQuery
+            {
+                Artist = "Knock2;Warren Hue;Holly;PIAO",
+                Album = "Shyne 4 Me",
+                Title = "Shyne 4 Me (feat. PIAO)",
+                Length = 200,
+            });
+
+            await searcher.SearchSong(song, settings.Search, new ResponseData(), CancellationToken.None);
+
+            Assert.AreEqual(3, client.SearchCallCount);
+            Assert.AreEqual(1, song.Candidates?.Count ?? 0);
+        }
+
+        [TestMethod]
         public async Task SearchSong_UpdatesActivityPhaseThroughSearchAndProjection()
         {
             var client = CreateMockClient(TestHelpers.CreateTestIndex());

--- a/Sockseek.Core.Tests/SearcherTests.cs
+++ b/Sockseek.Core.Tests/SearcherTests.cs
@@ -102,7 +102,7 @@ namespace Tests.Unit
 
             await searcher.SearchSong(song, settings.Search, new ResponseData(), CancellationToken.None);
 
-            Assert.AreEqual(2, client.SearchCallCount);
+            Assert.AreEqual(3, client.SearchCallCount);
             Assert.AreEqual(1, song.Candidates?.Count ?? 0);
         }
 

--- a/Sockseek.Core.Tests/SearcherTests.cs
+++ b/Sockseek.Core.Tests/SearcherTests.cs
@@ -85,6 +85,28 @@ namespace Tests.Unit
         }
 
         [TestMethod]
+        public async Task SearchSong_RetriesEachArtistWhenCombinedArtistSearchHasNoResults()
+        {
+            var response = new SearchResponse("User", 1, true, 1000, 0,
+            [
+                TestHelpers.CreateSlFile(@"Music\Knock2\What's the Move.mp3", length: 200),
+            ]);
+            var client = CreateMockClient([response]);
+            var settings = TestHelpers.CreateDefaultSettings().Download;
+            var searcher = CreateSearcher(client, settings);
+            var song = new SongJob(new SongQuery
+            {
+                Artist = "Henry Fong;Knock2;General Degree",
+                Title = "What's the Move",
+            });
+
+            await searcher.SearchSong(song, settings.Search, new ResponseData(), CancellationToken.None);
+
+            Assert.AreEqual(2, client.SearchCallCount);
+            Assert.AreEqual(1, song.Candidates?.Count ?? 0);
+        }
+
+        [TestMethod]
         public async Task SearchSong_UpdatesActivityPhaseThroughSearchAndProjection()
         {
             var client = CreateMockClient(TestHelpers.CreateTestIndex());

--- a/Sockseek.Core/Search/Searcher.cs
+++ b/Sockseek.Core/Search/Searcher.cs
@@ -595,10 +595,16 @@ public partial class Searcher : IDisposable
             var fallbackOpts = getSearchOptions(search.SearchTimeout, fallbackNecessaryCond, search.PreferredCond);
             foreach (string primaryArtist in GetArtists(query.Artist))
             {
-                searchTasks.Clear();
-                searchTasks.Add(DoSearch($"{primaryArtist} {query.Title}", fallbackOpts,
-                    responseHandler, noRemoveSpecialChars, ct, onSearch, ownerJob));
-                await Task.WhenAll(searchTasks);
+                foreach (string fallbackTitle in GetSearchTitles(query.Title))
+                {
+                    searchTasks.Clear();
+                    searchTasks.Add(DoSearch($"{primaryArtist} {fallbackTitle}", fallbackOpts,
+                        responseHandler, noRemoveSpecialChars, ct, onSearch, ownerJob));
+                    await Task.WhenAll(searchTasks);
+
+                    if (!results.IsEmpty)
+                        break;
+                }
 
                 if (!results.IsEmpty)
                     break;
@@ -713,6 +719,15 @@ public partial class Searcher : IDisposable
 
     private static IEnumerable<string> GetArtists(string artist)
         => artist.Split([';', ',', '&'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+    private static IEnumerable<string> GetSearchTitles(string title)
+    {
+        yield return title;
+
+        string titleWithoutFeaturedArtist = title.RemoveFt();
+        if (!string.Equals(titleWithoutFeaturedArtist, title, StringComparison.Ordinal))
+            yield return titleWithoutFeaturedArtist;
+    }
 
     private static string CleanSearchString(string str, bool removeSpecialChars)
     {

--- a/Sockseek.Core/Search/Searcher.cs
+++ b/Sockseek.Core/Search/Searcher.cs
@@ -587,13 +587,16 @@ public partial class Searcher : IDisposable
 
         if (results.IsEmpty && artist && title)
         {
+            bool sameTitleAlbum = album
+                && string.Equals(query.Album.Trim(), query.Title.Trim(), StringComparison.OrdinalIgnoreCase);
+            var fallbackNecessaryCond = sameTitleAlbum
+                ? new FileConditions(search.NecessaryCond) { LengthTolerance = -1 }
+                : search.NecessaryCond;
+            var fallbackOpts = getSearchOptions(search.SearchTimeout, fallbackNecessaryCond, search.PreferredCond);
             foreach (string primaryArtist in GetArtists(query.Artist))
             {
-                if (string.Equals(primaryArtist, query.Artist, StringComparison.Ordinal))
-                    continue;
-
                 searchTasks.Clear();
-                searchTasks.Add(DoSearch($"{primaryArtist} {query.Title}", defaultOpts,
+                searchTasks.Add(DoSearch($"{primaryArtist} {query.Title}", fallbackOpts,
                     responseHandler, noRemoveSpecialChars, ct, onSearch, ownerJob));
                 await Task.WhenAll(searchTasks);
 

--- a/Sockseek.Core/Search/Searcher.cs
+++ b/Sockseek.Core/Search/Searcher.cs
@@ -585,6 +585,23 @@ public partial class Searcher : IDisposable
 
         await Task.WhenAll(searchTasks);
 
+        if (results.IsEmpty && artist && title)
+        {
+            foreach (string primaryArtist in GetArtists(query.Artist))
+            {
+                if (string.Equals(primaryArtist, query.Artist, StringComparison.Ordinal))
+                    continue;
+
+                searchTasks.Clear();
+                searchTasks.Add(DoSearch($"{primaryArtist} {query.Title}", defaultOpts,
+                    responseHandler, noRemoveSpecialChars, ct, onSearch, ownerJob));
+                await Task.WhenAll(searchTasks);
+
+                if (!results.IsEmpty)
+                    break;
+            }
+        }
+
         if (results.IsEmpty && query.ArtistMaybeWrong && title)
         {
             var inferred = InferSongQuery(query.Title, new SongQuery());
@@ -690,6 +707,9 @@ public partial class Searcher : IDisposable
             return query.Artist.Trim();
         }
     }
+
+    private static IEnumerable<string> GetArtists(string artist)
+        => artist.Split([';', ',', '&'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
     private static string CleanSearchString(string str, bool removeSpecialChars)
     {


### PR DESCRIPTION
Fixes #206

## Summary
- Keep the combined artist and title search as the first attempt.
- When it returns no results, retry with each artist split on semicolon, comma, or ampersand.
- Stop retrying after the first artist search returns results.
- Preserve the original SongQuery artist metadata for result handling.

## Tests
- Added a regression test covering the reported multi-artist case.